### PR TITLE
Correct library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Gijs Withagen <gijs.withagen@xs4all.nl>
 sentence=A library for controlling VID28 or equivalent stepper motors (BKA30D-R5, X25).
 paragraph=Supports 6 step controllig or controllig using microsteps (PWM). 
 category=Device Control
-url=https:/github.com/GewoonGijs/VID28.git
+url=https://github.com/GewoonGijs/VID28.git
 architectures=avr
 includes=MotorVID28.h


### PR DESCRIPTION
The `url` value in library.properties had a malformed URL scheme.