### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,18 +5,18 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-MotorVID28 
+MotorVID28	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 StepUp	KEYWORD2
-StepDown KEYWORD2
-update KYEYWORD2
-setPosition KEYWORD2
-powerOff KEYWORD2
-setPrescaler KEYWORD2
+StepDown	KEYWORD2
+update	KEYWORD2
+setPosition	KEYWORD2
+powerOff	KEYWORD2
+setPrescaler	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords